### PR TITLE
Fixed fractional second parsing with a single digit hour.

### DIFF
--- a/lib/parseformat.js
+++ b/lib/parseformat.js
@@ -37,6 +37,9 @@ var regexISO8601HoursWithLeadingZeroMinutesSecondsDeciSeconds = /\d{2}:\d{2}:\d{
 var regexHoursWithLeadingZeroMinutesSeconds = /0\d:\d{2}:\d{2}/
 var regexHoursWithLeadingZeroMinutes = /0\d:\d{2}/
 var regexHoursMinutesSeconds = /\d{1,2}:\d{2}:\d{2}/
+var regexHoursMinutesSecondsMilliseconds = /\d{1,2}:\d{2}:\d{2}\.\d{3}/
+var regexHoursMinutesSecondsCentiSeconds = /\d{1,2}:\d{2}:\d{2}\.\d{2}/
+var regexHoursMinutesSecondsDeciSeconds = /\d{1,2}:\d{2}:\d{2}\.\d{1}/
 var regexHoursMinutes = /\d{1,2}:\d{2}/
 var regexYearLong = /\d{4}/
 var regexDayLeadingZero = /0\d/
@@ -126,6 +129,12 @@ function parseFormat (dateString, options) {
   format = format.replace(regexHoursAmPm, 'h$1')
   // 05:30:20 ☛ HH:mm:ss
   format = format.replace(regexHoursWithLeadingZeroMinutesSeconds, 'HH:mm:ss')
+  //5:30:20.222 ☛ H:mm:ss.SSS
+  format = format.replace(regexHoursMinutesSecondsMilliseconds, 'H:mm:ss.SSS')
+  //5:30:20.222 ☛ H:mm:ss.SS
+  format = format.replace(regexHoursMinutesSecondsCentiSeconds, 'H:mm:ss.SS')
+  //5:30:20.222 ☛ H:mm:ss.S
+  format = format.replace(regexHoursMinutesSecondsDeciSeconds, 'H:mm:ss.S')
   // 10:30:20 ☛ H:mm:ss
   format = format.replace(regexHoursMinutesSeconds, 'H:mm:ss')
   // 05:30 ☛ H:mm

--- a/lib/parseformat.js
+++ b/lib/parseformat.js
@@ -131,9 +131,9 @@ function parseFormat (dateString, options) {
   format = format.replace(regexHoursWithLeadingZeroMinutesSeconds, 'HH:mm:ss')
   // 5:30:20.222 ☛ H:mm:ss.SSS
   format = format.replace(regexHoursMinutesSecondsMilliseconds, 'H:mm:ss.SSS')
-  // 5:30:20.222 ☛ H:mm:ss.SS
+  // 5:30:20.22 ☛ H:mm:ss.SS
   format = format.replace(regexHoursMinutesSecondsCentiSeconds, 'H:mm:ss.SS')
-  // 5:30:20.222 ☛ H:mm:ss.S
+  // 5:30:20.2 ☛ H:mm:ss.S
   format = format.replace(regexHoursMinutesSecondsDeciSeconds, 'H:mm:ss.S')
   // 10:30:20 ☛ H:mm:ss
   format = format.replace(regexHoursMinutesSeconds, 'H:mm:ss')

--- a/lib/parseformat.js
+++ b/lib/parseformat.js
@@ -129,11 +129,11 @@ function parseFormat (dateString, options) {
   format = format.replace(regexHoursAmPm, 'h$1')
   // 05:30:20 ☛ HH:mm:ss
   format = format.replace(regexHoursWithLeadingZeroMinutesSeconds, 'HH:mm:ss')
-  //5:30:20.222 ☛ H:mm:ss.SSS
+  // 5:30:20.222 ☛ H:mm:ss.SSS
   format = format.replace(regexHoursMinutesSecondsMilliseconds, 'H:mm:ss.SSS')
-  //5:30:20.222 ☛ H:mm:ss.SS
+  // 5:30:20.222 ☛ H:mm:ss.SS
   format = format.replace(regexHoursMinutesSecondsCentiSeconds, 'H:mm:ss.SS')
-  //5:30:20.222 ☛ H:mm:ss.S
+  // 5:30:20.222 ☛ H:mm:ss.S
   format = format.replace(regexHoursMinutesSecondsDeciSeconds, 'H:mm:ss.S')
   // 10:30:20 ☛ H:mm:ss
   format = format.replace(regexHoursMinutesSeconds, 'H:mm:ss')

--- a/test/moment-parseformat-test.js
+++ b/test/moment-parseformat-test.js
@@ -60,6 +60,10 @@ test('GitHub issues', function (t) {
   t.equal(moment.parseFormat('October 27 2015 11:28:32.01'), 'MMMM D YYYY HH:mm:ss.SS', 'October 27 2015 11:28:32.0 → MMMM D YYYY HH:mm:ss.SS')
   t.equal(moment.parseFormat('October 27 2015 11:28:32.012'), 'MMMM D YYYY HH:mm:ss.SSS', 'October 27 2015 11:28:32.0 → MMMM D YYYY HH:mm:ss.SSS')
 
+  // https://github.com/gr2m/moment-parseformat/pull/NEW pull
+  t.equal(moment.parseFormat('Feb 1 2016 1:03:22.111'), 'MMM D YYYY H:mm:ss.SSS', 'Feb 1 2016 1:03:22.111 → MMM D YYYY H:mm:ss.SSS')
+  t.equal(moment.parseFormat('Feb 1 2016 1:03:22.11'), 'MMM D YYYY H:mm:ss.SS', 'Feb 1 2016 1:03:22.111 → MMM D YYYY H:mm:ss.SS')
+  t.equal(moment.parseFormat('Feb 1 2016 1:03:22.1'), 'MMM D YYYY H:mm:ss.S', 'Feb 1 2016 1:03:22.111 → MMM D YYYY H:mm:ss.S')
   t.end()
 })
 

--- a/test/moment-parseformat-test.js
+++ b/test/moment-parseformat-test.js
@@ -60,7 +60,7 @@ test('GitHub issues', function (t) {
   t.equal(moment.parseFormat('October 27 2015 11:28:32.01'), 'MMMM D YYYY HH:mm:ss.SS', 'October 27 2015 11:28:32.0 → MMMM D YYYY HH:mm:ss.SS')
   t.equal(moment.parseFormat('October 27 2015 11:28:32.012'), 'MMMM D YYYY HH:mm:ss.SSS', 'October 27 2015 11:28:32.0 → MMMM D YYYY HH:mm:ss.SSS')
 
-  // https://github.com/gr2m/moment-parseformat/pull/NEW pull
+  // https://github.com/gr2m/moment-parseformat/pull/45
   t.equal(moment.parseFormat('Feb 1 2016 1:03:22.111'), 'MMM D YYYY H:mm:ss.SSS', 'Feb 1 2016 1:03:22.111 → MMM D YYYY H:mm:ss.SSS')
   t.equal(moment.parseFormat('Feb 1 2016 1:03:22.11'), 'MMM D YYYY H:mm:ss.SS', 'Feb 1 2016 1:03:22.111 → MMM D YYYY H:mm:ss.SS')
   t.equal(moment.parseFormat('Feb 1 2016 1:03:22.1'), 'MMM D YYYY H:mm:ss.S', 'Feb 1 2016 1:03:22.111 → MMM D YYYY H:mm:ss.S')


### PR DESCRIPTION
There was an issue with parsing fractional seconds when using a single digit hour. For example, 05:30:11.111 worked just fine, but 5:30:11.111 reported the wrong pattern. This commit fixes that issue.