### PR TITLE
Parses ISO 8601 UTC Offsets Without Colons

### DIFF
--- a/lib/parseformat.js
+++ b/lib/parseformat.js
@@ -19,7 +19,7 @@ var regexAbbreviatedMonthNames = new RegExp(abbreviatedMonthNames.join('|'), 'i'
 var regexFirstSecondThirdFourth = /(\d+)(st|nd|rd|th)\b/i
 var regexEndian = /(\d{1,4})([\/\.\-])(\d{1,2})[\/\.\-](\d{1,4})/
 
-var regexTimezone = /((\+|\-)\d\d:\d\d)$/
+var regexTimezone = /((\+|\-)\d\d:?\d\d)$/
 var amOrPm = '(' + [amDesignator, pmDesignator].join('|') + ')'
 var lowerAmOrPm = '(' + [lowerAMDesignator, lowerPMDesignator].join('|') + ')'
 var regexLowerAmOrPm = new RegExp(lowerAmOrPm)

--- a/test/moment-parseformat-test.js
+++ b/test/moment-parseformat-test.js
@@ -64,6 +64,12 @@ test('GitHub issues', function (t) {
   t.equal(moment.parseFormat('Feb 1 2016 1:03:22.111'), 'MMM D YYYY H:mm:ss.SSS', 'Feb 1 2016 1:03:22.111 → MMM D YYYY H:mm:ss.SSS')
   t.equal(moment.parseFormat('Feb 1 2016 1:03:22.11'), 'MMM D YYYY H:mm:ss.SS', 'Feb 1 2016 1:03:22.111 → MMM D YYYY H:mm:ss.SS')
   t.equal(moment.parseFormat('Feb 1 2016 1:03:22.1'), 'MMM D YYYY H:mm:ss.S', 'Feb 1 2016 1:03:22.111 → MMM D YYYY H:mm:ss.S')
+
+  // https://github.com/gr2m/moment-parseformat/issues/56
+  t.equal(moment.parseFormat('2014-23-04T01:20:28.888+0200'), 'YYYY-MM-DDTHH:mm:ss.SSSZ', '#56 2014-23-04T01:20:28.888+0200 → YYYY-MM-DDTHH:mm:ss.SSSZ')
+  t.equal(moment.parseFormat('2014-09-04T01:20:28.888+0200'), 'YYYY-MM-DDTHH:mm:ss.SSSZ', '#56 2014-09-04T01:20:28.888+0200 → YYYY-MM-DDTHH:mm:ss.SSSZ')
+  t.equal(moment.parseFormat('2014-09-04T01:20:28.888-0200'), 'YYYY-MM-DDTHH:mm:ss.SSSZ', '#56 2014-09-04T01:20:28.888-0200 → YYYY-MM-DDTHH:mm:ss.SSSZ')
+  t.equal(moment.parseFormat('2014-09-04T01:20:28+0200'), 'YYYY-MM-DDTHH:mm:ssZ', '#56 2014-09-04T01:20:28+0200 → YYYY-MM-DDTHH:mm:ssZ')
   t.end()
 })
 


### PR DESCRIPTION
- Updated the regexTimezone to make the UTC Offset colon optional for
  an ISO 8601 formatted date-time
- References #56 