### PR TITLE
CI: stop testing in Node 4 & 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,10 @@ branches:
 jobs:
   include:
     # run tests in all supported node versions
-    # run coverage only in Node 9
-    - node_js: 4
+    # run coverage only in Node 10
     - node_js: 6
     - node_js: 8
-    - node_js: 9
+    - node_js: 10
       script:
         - npm run test
         - npm run test:coverage


### PR DESCRIPTION
fixes #83

BREAKING CHANGE: drop support for Node 4 & Node 9

Currently supported Node versions are : 6, 8 and 10. See [Node LTS Schedule](https://github.com/nodejs/Release#lts-schedule)