### PR TITLE
ci(release): add permissions for OIDC and npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,19 @@ name: Release
       - next
       - beta
       - "*.x"
+permissions:
+  id-token: write # to enable use of OIDC for trusted publishing and npm provenance
+  contents: write # tags and releases
+  pull-requests: write # comments
+  issues: write # comments
+
 jobs:
   release:
     name: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: lts/*
       - run: npm ci
@@ -20,4 +26,3 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Add permissions for OIDC, contents, pull-requests, and issues.

This enables [npm provenance](https://docs.npmjs.com/generating-provenance-statements) via trusted publishing — the `NPM_TOKEN` secret is no longer needed once the npm package is configured to trust GitHub Actions as a publisher.

Also updates `actions/checkout` and `actions/setup-node` to v4.